### PR TITLE
Add FLOAT64 datatype for 64-bit double floats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "rollup": "^2.80.0",
         "ts-mocha": "^9.0.2",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3281,15 +3284,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/type-fest": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
@@ -5810,14 +5804,6 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
-    },
-    "tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -14,6 +14,7 @@ import {
   BINARY,
   UINT32,
   FLOAT,
+  FLOAT64,
   packParallel,
   packParts,
   combinePackedParts,
@@ -57,6 +58,10 @@ describe("MetaPack test", () => {
     const packed_FLOAT = pack(123.456, FLOAT);
     const unpacked_FLOAT = unpack(packed_FLOAT, FLOAT);
     expect(unpacked_FLOAT).toBeCloseTo(123.456, 3);
+
+    const packed_FLOAT64 = pack(123.456, FLOAT64);
+    const unpacked_FLOAT64 = unpack(packed_FLOAT64, FLOAT64);
+    expect(unpacked_FLOAT64).toBe(123.456);
 
     const packed_BOOL_true = pack(true, BOOL);
     const unpacked_BOOL_true = unpack(packed_BOOL_true, BOOL);
@@ -334,6 +339,103 @@ describe("MetaPack test", () => {
     expect(() => unpack(pack(1, UINT8), null as any)).toThrow("Invalid schema!");
     expect(() => unpack(pack(1, UINT8), undefined as any)).toThrow("Invalid schema!");
     expect(unpack(pack(1, UINT8), "abc" as any)).toBeUndefined();
+  });
+});
+
+describe("FLOAT64 (double precision) coverage", () => {
+  const opts = { useCheckSum: false, useEncrypt: false };
+
+  it("should preserve full double precision (where FLOAT32 cannot)", () => {
+    const value = 3.141592653589793; // more precision than a 32-bit float holds
+    const packed = pack(value, FLOAT64);
+    const unpacked = unpack(packed, FLOAT64);
+    // Exact equality — no precision loss
+    expect(unpacked).toBe(value);
+
+    // FLOAT (32-bit) loses precision on the same value
+    const float32 = unpack(pack(value, FLOAT), FLOAT);
+    expect(float32).not.toBe(value);
+  });
+
+  it("should use 8 bytes on the wire", () => {
+    const ctx = new PackerContext(0);
+    doPackCtx(ctx, 1.5, FLOAT64);
+    expect(ctx.getResult().length).toEqual(8);
+  });
+
+  it("should handle numeric edge cases", () => {
+    const cases = [
+      0,
+      -0,
+      1,
+      -1,
+      0.1,
+      -0.000123456789,
+      Number.MAX_SAFE_INTEGER + 0.5,
+      Number.MAX_VALUE,
+      Number.MIN_VALUE,
+      1e308,
+      -1e308,
+      Math.PI,
+      Math.E,
+    ];
+    for (const value of cases) {
+      const unpacked = unpack(pack(value, FLOAT64), FLOAT64);
+      expect(unpacked).toBe(value);
+    }
+  });
+
+  it("should handle Infinity, -Infinity and NaN", () => {
+    expect(unpack(pack(Infinity, FLOAT64), FLOAT64)).toBe(Infinity);
+    expect(unpack(pack(-Infinity, FLOAT64), FLOAT64)).toBe(-Infinity);
+    expect(Number.isNaN(unpack(pack(NaN, FLOAT64), FLOAT64))).toBe(true);
+  });
+
+  it("should throw for non-number input", () => {
+    expect(() => pack("x", FLOAT64)).toThrow(
+      "Invalid data type for FLOAT64. Expected number."
+    );
+  });
+
+  it("should work inside arrays", () => {
+    const schema = [FLOAT64];
+    const value = [1.1, 2.2, 3.3, 4.4];
+    const packed = pack(value, schema, opts);
+    const unpacked = unpack(packed, schema, opts);
+    expect(unpacked).toEqual(value);
+  });
+
+  it("should work inside nested objects", () => {
+    const schema = { lat: FLOAT64, lng: FLOAT64, meta: { alt: FLOAT64 } };
+    const value = { lat: 51.50735090000001, lng: -0.12775829999998223, meta: { alt: 35.123456789 } };
+    const packed = pack(value, schema, opts);
+    const unpacked = unpack(packed, schema, opts);
+    expect(unpacked).toEqual(value);
+  });
+
+  it("should round-trip with checksum and encryption", () => {
+    const value = 9876.543210123456;
+    const finalOpts = { useCheckSum: true, useEncrypt: true, secret: 42 };
+    const packed = pack(value, FLOAT64, finalOpts);
+    const unpacked = unpack(packed, FLOAT64, finalOpts);
+    expect(unpacked).toBe(value);
+  });
+
+  it("should be skipped correctly by splitPackedParts", () => {
+    const schema = { a: FLOAT64, b: STRING };
+    const data = { a: 2.718281828459045, b: "after" };
+    const packed = pack(data, schema, opts);
+    const parts = splitPackedParts(packed, schema as any, opts);
+    // The FLOAT64 field must consume exactly 8 bytes so the next field aligns
+    expect(parts["a"].length).toEqual(8);
+    expect(unpackPart(parts["a"], FLOAT64)).toBe(data.a);
+    expect(unpackPart(parts["b"], STRING)).toBe(data.b);
+  });
+
+  it("should trigger buffer grow with a tiny context", () => {
+    const ctx = new PackerContext(0);
+    doPackCtx(ctx, 6.022e23, FLOAT64);
+    expect(unpackPart(ctx.getResult(), FLOAT64)).toBe(6.022e23);
   });
 });
 

--- a/src/packer.ts
+++ b/src/packer.ts
@@ -101,6 +101,12 @@ export function doPackCtx(ctx: PackerContext, data: any, schema: Schema | Array<
         ctx.view.setFloat32(ctx.offset, data, false);
         ctx.offset += 4;
         return;
+      case DataTypes.FLOAT64:
+        if (typeof data !== 'number') throw new Error('Invalid data type for FLOAT64. Expected number.');
+        if (ctx.offset + 8 > ctx.buf.length) ctx.grow(8);
+        ctx.view.setFloat64(ctx.offset, data, false);
+        ctx.offset += 8;
+        return;
       case DataTypes.BINARY: {
         if (!(data instanceof Uint8Array)) throw new Error('Invalid data type for BINARY. Expected Uint8Array.');
         const len = data.length;

--- a/src/unpacker.ts
+++ b/src/unpacker.ts
@@ -59,6 +59,10 @@ function doUnpack(
         val = view.getFloat32(ctx.offset, false);
         ctx.offset += 4;
         return val;
+      case DataTypes.FLOAT64:
+        val = view.getFloat64(ctx.offset, false);
+        ctx.offset += 8;
+        return val;
       case DataTypes.BINARY: {
         const length = view.getUint32(ctx.offset, false);
         ctx.offset += 4;
@@ -156,6 +160,7 @@ function skipSchema(
         return;
       case DataTypes.UINT64:
       case DataTypes.INT64:
+      case DataTypes.FLOAT64:
         ctx.offset += 8;
         return;
       case DataTypes.BINARY:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,7 @@ export enum DataTypes {
   BINARY,
   STRING,
   OBJECT,
+  FLOAT64,
 }
 
 export const UINT8 = DataTypes.UINT8 as const;
@@ -25,6 +26,7 @@ export const INT32 = DataTypes.INT32 as const;
 export const INT64 = DataTypes.INT64 as const;
 export const BOOL = DataTypes.BOOL as const;
 export const FLOAT = DataTypes.FLOAT as const;
+export const FLOAT64 = DataTypes.FLOAT64 as const;
 export const BINARY = DataTypes.BINARY as const;
 export const STRING = DataTypes.STRING as const;
 export const OBJECT = DataTypes.OBJECT as const;
@@ -46,6 +48,7 @@ export type DataTypeMap = {
   [DataTypes.INT64]: bigint;
   [DataTypes.BOOL]: boolean;
   [DataTypes.FLOAT]: number;
+  [DataTypes.FLOAT64]: number;
   [DataTypes.BINARY]: Uint8Array;
   [DataTypes.STRING]: string;
   [DataTypes.OBJECT]: object;


### PR DESCRIPTION
Description:
  ## Summary
  - Add a new `FLOAT64` datatype for 64-bit double-precision floating point
  numbers, complementing the existing 32-bit `FLOAT`.
  - Appended to the end of the `DataTypes` enum so existing type values don't
  shift and previously-packed buffers stay compatible.
  - Packs/unpacks 8 bytes in big-endian order via `setFloat64`/`getFloat64`,
  matching the library's byte-order convention.
  - Wired into `skipSchema` (8-byte group) so part-splitting advances the
  correct offset.
  
  ## Test plan
  - Added a dedicated `FLOAT64 (double precision) coverage` suite:
  full-precision round-trip (vs. 32-bit precision loss), 8-byte wire size,
  numeric edge cases, `Infinity`/`-Infinity`/`NaN`, type-error, arrays, nested
  objects, checksum + encryption, `splitPackedParts` alignment, and
  buffer-grow.
  - `npm test` — 63 passing.